### PR TITLE
Fix YM3802 MIDI timing and TX FIFO behavior

### DIFF
--- a/rtl/X68K_top.vhd
+++ b/rtl/X68K_top.vhd
@@ -823,6 +823,8 @@ signal	midi_ivect	:std_logic_vector(7 downto 0);
 --puu
 signal	midi_sft		:std_logic;
 constant midis_div	:integer	:=(SCFREQ/1000)-1;
+signal midi_msft       :std_logic;
+constant midim_div     :integer        :=(SCFREQ/250)-1;  -- 250 kHz
 signal	midi_csft	:std_logic;
 
 --Contrast controller
@@ -4539,9 +4541,9 @@ begin
 		GPIN	=>(others=>'1'),
 		GPOE	=>open,
 		
-		gcountsft	=>midi_Sft,		--typo???
+		gcountsft       =>midi_sft,		--typo???
 		ccountsft	=>midi_csft,
-		mcountsft	=>midi_sft,
+		mcountsft       =>midi_msft,
 		
 		clk	=>sysclk,
 		ce  =>sys_ce,
@@ -4555,6 +4557,14 @@ begin
 		clk		=>sysclk,
 		ce  		=>sys_ce,
 		rstn		=>srstn
+	);
+	midim	: sftgen generic map(midim_div) port map(
+		len		=>midim_div,
+		sft		=>midi_msft,
+
+		clk		=>sysclk,
+		ce		=>sys_ce,
+		rstn	=>srstn
 	);
 
 	midics	:sftnpn generic map(5) port map(

--- a/rtl/sound/midiif/em3802.vhd
+++ b/rtl/sound/midiif/em3802.vhd
@@ -175,6 +175,9 @@ signal	intnum	:std_logic_vector(3 downto 0);
 signal	gcounter	:std_logic_vector(13 downto 0);
 signal	ccounter	:std_logic_vector(6 downto 0);
 signal	mcounter	:std_logic_vector(13 downto 0);
+
+signal  mscrstep    :std_logic_vector(13 downto 0);
+signal  mclk        :std_logic;
 constant gczero	:std_logic_Vector(13 downto 0)	:=(others=>'0');
 constant cczero	:std_logic_vector(6 downto 0)		:=(others=>'0');
 constant mczero	:std_logic_Vector(13 downto 0)	:=(others=>'0');
@@ -282,7 +285,7 @@ end component;
 
 begin
 
-	txfifo	:datfifo generic map(64,8) port map(
+	txfifo	:datfifo generic map(256,8) port map(
 		datin		=>txfifowdat,
 		datwr		=>txfifowr,
 		
@@ -386,7 +389,7 @@ begin
 			intclr<=(others=>'0');
 			R01<=(others=>'0');
 			R04<=(others=>'0');
-			R05<=(others=>'0');
+			R05<=x"02";
 			R06<=(others=>'0');
 			R14<=(others=>'0');
 			R24<=(others=>'0');
@@ -453,7 +456,7 @@ begin
 				intclr<=(others=>'0');
 				R01<=(others=>'0');
 				R04<=(others=>'0');
-				R05<=(others=>'0');
+				R05<=x"02";
 				R06<=(others=>'0');
 				R14<=(others=>'0');
 				R24<=(others=>'0');
@@ -650,6 +653,7 @@ begin
 	CCLDVAL<=R67(6 downto 0);
 	PCADDVAL<=R77(6 downto 0) & R76;
 	INTRATE<=R75(3 downto 0);
+	mscrstep <= "00000000000001" when R75(3 downto 0)=x"0" else "0000000000" & R75(3 downto 0);
 	GTLDVAL<=R85(5 downto 0) & R84;
 	MTLDVAL<=R87(5 downto 0) & R86;
 	GPOE<=R94;
@@ -1240,7 +1244,7 @@ begin
 				end if;
 				if(CCLD='1')then
 					ccounter<=CCLDVAL;
-				elsif(ccountsft='1')then
+				elsif(mclk='1')then
 					if(ccounter>0)then
 						ccounter<=ccounter-1;
 					elsif(CCLDVAL/=cczero)then
@@ -1258,17 +1262,24 @@ begin
 
 		if(rstn='0')then
 			mcounter<=(others=>'0');
+			mclk<='0';
+
 		elsif(ce ='1')then
+			mclk<='0';
+
 			if(sreset='1')then
 				mcounter<=(Others=>'0');
+
 			else
 				if(MTLD='1')then
 					mcounter<=MTLDVAL;
+
 				elsif(mcountsft='1')then
-					if(mcounter>0)then
-						mcounter<=mcounter-1;
+					if(mcounter>mscrstep)then
+						mcounter<=mcounter-mscrstep;
 					elsif(MTLDVAL/=mczero)then
 						mcounter<=MTLDVAL;
+						mclk<='1';
 					end if;
 				end if;
 			end if;
@@ -1284,8 +1295,8 @@ begin
 	intmm<='0';
 	
 	intx<=intgt & inttx & intrx & intol & intrc & intpc & intcc & intmm;
-	intm<=intx and intmask;
-	R02<=intm;
+	intm<=(intx and intmask) when R05(1)='1' else (others=>'0');
+	R02<=intx;
 	
 	process(intm)
 	variable num	:integer range 0 to 8;


### PR DESCRIPTION
## Summary

This PR improves the YM3802/EM3802 MIDI implementation used by the X68000 core.

The changes address MIDI hangs/stalls observed in some titles and improve MIDI timer behavior to better match XM6.

## Changes

- Increase the EM3802 TX FIFO depth from 64 to 256 bytes.
- Add a dedicated MIDI timer shift clock for MTR handling.
- Route MTR expiration through the clock counter path so CTR/CDR generates the interrupt.
- Apply SCR stepping from R75[3:0], treating SCR=0 as 1.
- Initialize the interrupt mode register equivalent to 0x02.
- Expose raw interrupt status through R02 while gating interrupt generation by R05(1) and R06.

## Rationale

XM6 models the YM3802 MIDI timer as:

- MTR/SCR drives the MIDI clock event.
- The MIDI clock decrements CTR.
- CTR/CDR generates interrupt type 1 when it expires.
- SCR=0 is treated as 1.
- IMR is initialized with bit 1 set.

This PR updates the MiSTer EM3802 implementation to follow that behavior more closely.

## Tested

Tested with external MIDI output using a Roland UM-One USB MIDI interface with SC55 and MT-32 module.

Confirmed working:

- Final Fight: MIDI no longer stalls/hangs.
- Mahou Daisakusen: Now work with MIDI and plays at correct speed.
- Multiple other MIDI titles tested successfully.