### PR TITLE
Fix reversed OPM stereo channels

### DIFF
--- a/rtl/X68K_top.vhd
+++ b/rtl/X68K_top.vhd
@@ -4329,8 +4329,8 @@ begin
 	opm_intn     <= jt51_intn    when opm_sel='0' else ikaopm_intn;
 	pcm_clkmode  <= jt51_ct2     when opm_sel='0' else ikaopm_ct2;
 	opm_ct2      <= jt51_ct1     when opm_sel='0' else ikaopm_ct1;
-	opm_sndl     <= jt51_sndl    when opm_sel='0' else ikaopm_sndl;
-	opm_sndr     <= jt51_sndr    when opm_sel='0' else ikaopm_sndr;
+	opm_sndl     <= jt51_sndr    when opm_sel='0' else ikaopm_sndr;
+	opm_sndr     <= jt51_sndl    when opm_sel='0' else ikaopm_sndl;
 
 	pcm_ce<='1' when abus(23 downto 2)="1110100100100000000000" else '0';
 	pcm_wr<=b_wr(0) when pcm_ce='1' else '0';


### PR DESCRIPTION
## Summary

This fixes reversed OPM/FM stereo channels in the X68000 core.

The issue is visible in Cho Ren Sha 68K and is already tracked in #28. In the music test, the stereo pan direction on MiSTer is reversed compared to XM6G/reference behavior.

This change swaps only the OPM/FM path:

- `opm_sndl` now receives the right OPM output
- `opm_sndr` now receives the left OPM output

The ADPCM/PCM path is not changed.

## Validation

Tested with:

### Cho Ren Sha 68K

Using the music test, the first music track has an obvious stereo pan in the drum/percussion part.

- XM6G/reference: pan moves right-to-left
- MiSTer before this patch: pan moved left-to-right
- MiSTer after this patch: pan matches XM6G/reference

Related to #28.

### Akumajou Dracula

Also tested with Akumajou Dracula, where the OPM/FM stereo channel placement is very noticeable.

- XM6G was used as reference
- MiSTer before this patch had the OPM/FM channels reversed
- MiSTer after this patch matches XM6G

## Scope

This patch only swaps the OPM/FM signal assignment before the final mix:

```vhdl
opm_sndl <= jt51_sndr when opm_sel='0' else ikaopm_sndr;
opm_sndr <= jt51_sndl when opm_sel='0' else ikaopm_sndl;