### PR TITLE
Fix IKAOPM timer status flags when IRQ is disabled

### DIFF
--- a/rtl/sound/IKAOPM/IKAOPM_timer.v
+++ b/rtl/sound/IKAOPM/IKAOPM_timer.v
@@ -114,19 +114,17 @@ always @(posedge i_EMUCLK) if(!phi1ncen_n) begin
         o_TIMERA_FLAG <= 1'b0;
     end
     else begin
-        if(i_TIMERA_IRQ_EN) o_TIMERA_FLAG <= timera_ovfl_z | o_TIMERA_FLAG;
-        else o_TIMERA_FLAG <= 1'b0;
+        o_TIMERA_FLAG <= timera_ovfl_z | o_TIMERA_FLAG;
     end
 
     if(~mrst_n || i_TIMERB_FRST) begin
         o_TIMERB_FLAG <= 1'b0;
     end
     else begin
-        if(i_TIMERB_IRQ_EN) o_TIMERB_FLAG <= timerb_ovfl_z | o_TIMERB_FLAG;
-        else o_TIMERB_FLAG <= 1'b0;
+        o_TIMERB_FLAG <= timerb_ovfl_z | o_TIMERB_FLAG;
     end
 
-    o_IRQ_n <= ~(o_TIMERA_FLAG | o_TIMERB_FLAG);
+    o_IRQ_n <= ~((o_TIMERA_FLAG & i_TIMERA_IRQ_EN) | (o_TIMERB_FLAG & i_TIMERB_IRQ_EN));
 end
 
 endmodule


### PR DESCRIPTION
## Summary

Fix the IKAOPM Timer A and Timer B status flags being incorrectly gated by their corresponding IRQ enable bits.

This fixes missing music in Ultima V when the IKAOPM core is selected.

## Problem

Ultima V works correctly with JT51, but no music is played when IKAOPM is selected.

The game uses Timer A status polling to drive its music routine. It starts Timer A and checks bit 0 of the YM2151 status register for an overflow event, without necessarily enabling the Timer A interrupt.

In the previous IKAOPM implementation, the timer status flag was forced low whenever the corresponding IRQ enable bit was disabled:

if(i_TIMERA_IRQ_EN)
    o_TIMERA_FLAG <= timera_ovfl_z | o_TIMERA_FLAG;
else
    o_TIMERA_FLAG <= 1'b0;

As a result, Timer A could overflow internally, but the overflow was never visible through bit 0 of the status register when Timer A IRQ was disabled.

Ultima V therefore waited indefinitely for a Timer A status flag that could never be set, preventing the music routine from advancing.

## Fix

Timer A and Timer B status flags now latch on overflow independently of their IRQ enable bits.

The IRQ enable bits are applied only when generating the external IRQ output:

o_IRQ_n <= ~(
    (o_TIMERA_FLAG & i_TIMERA_IRQ_EN) |
    (o_TIMERB_FLAG & i_TIMERB_IRQ_EN)
);

This separates the two YM2151 behaviors:

- Timer overflow flags indicate timer overflow events.
- IRQ enable bits control whether those flags assert the external IRQ output.

The existing flag reset behavior through register 0x14 remains unchanged.

## Validation

The issue was isolated through the following tests:

1. IKAOPM with its original status output:
   Ultima V had no music.

2. Registered IKAOPM clock enable:
   Ultima V still had no music.

3. IKAOPM with FULLY_SYNCHRONOUS set to 0:
   Ultima V still had no music.

4. IKAOPM audio with JT51 status and IRQ:
   Music worked.

5. IKAOPM audio and IRQ with JT51 status only:
   Music worked.

6. JT51 busy bit with IKAOPM timer flags:
   Music did not work.

7. IKAOPM busy and Timer B flag with only the JT51 Timer A flag:
   Music worked.

8. Native IKAOPM timer flag fix, without using any JT51 status or timer signals:
   Music worked correctly.

These tests confirmed that the synthesis engine, register writes, busy flag, Timer B status, and IRQ output were not the cause. The incompatibility was specifically caused by the Timer A status flag being cleared whenever Timer A IRQ was disabled.

## Result

Ultima V now plays music correctly with IKAOPM selected, without relying on JT51 for status, timer, IRQ, or audio processing.

This is not an Ultima V-specific workaround. It corrects the separation between timer status flags and interrupt enable behavior in the YM2151 interface.