### PR TITLE
Fix text palette color 0 handling in the VC compositor

### DIFF
--- a/rtl/VIDEO/vc_compositor.vhd
+++ b/rtl/VIDEO/vc_compositor.vhd
@@ -154,8 +154,8 @@ begin
 
         if spren = '0' and txten = '1' and tx_pal_eff = 0 then
             rep_source := SRC_TX;
-            rep_color  := (others => '0');
-            st_present := false;
+            rep_color  := tx_color0;
+            st_present := tx_color0 /= x"0000";
         end if;
 
         if pri_gr = "11" and gr_present then


### PR DESCRIPTION
A Discord user reported a regression affecting the Lemmings startup DMA Design logo. Further testing identified that the issue was introduced in the 20260614 test build.

Comparison using the XM6G video debugger showed that text palette color 0 is a valid visible color used for the white background. The VC compositor incorrectly replaced this color with zero and treated the text layer as absent.

Use tx_color0 for text palette index 0 and keep the source active when the resulting color is nonzero.

Verified on MiSTer hardware. The logo background now matches XM6G.