### PR TITLE
Fix text palette color 0 handling based on layer priority

### DIFF
--- a/rtl/VIDEO/vc_compositor.vhd
+++ b/rtl/VIDEO/vc_compositor.vhd
@@ -154,8 +154,13 @@ begin
 
         if spren = '0' and txten = '1' and tx_pal_eff = 0 then
             rep_source := SRC_TX;
-            rep_color  := (others => '0');
-            st_present := false;
+            if unsigned(pri_tx) > unsigned(pri_gr) then
+                rep_color  := tx_color0;
+                st_present := tx_color0 /= x"0000";
+            else
+                rep_color  := (others => '0');
+                st_present := false;
+            end if;
         end if;
 
         if pri_gr = "11" and gr_present then


### PR DESCRIPTION
This change corrects the priority handling of text pixels using color 0.

A previous fix for graphical corruption in Afalin introduced a regression affecting other games. In Lemmings, the DMA Design logo was no longer displayed correctly. The updated priority logic preserves the Afalin fix while restoring the correct rendering of the DMA Design logo in Lemmings.

Both affected games now render correctly. The change was also tested with several other games, and no regressions were found.