### PR TITLE
Fix MFP V-DISP during dynamic CRTC mode changes

### DIFF
--- a/rtl/X68K_top.vhd
+++ b/rtl/X68K_top.vhd
@@ -4237,12 +4237,12 @@ begin
 	mfp_gpip7<=VID_HRTCi;
 	mfp_gpip6<=not VID_RINT;
 	mfp_gpip5<='1';
-	mfp_gpip4<=VID_VVIDEN;
+	mfp_gpip4<=not VID_VRTC;
 	mfp_gpip3<=opm_intn;
 	mfp_gpip2<=pwrsw;
 	mfp_gpip1<='1';
 	mfp_gpip0<=not rtc_alarm;
-	mfp_tai<=not VID_VVIDEN;
+	mfp_tai<=VID_VRTC;
 
 	UMFP	:MFP generic map(SCFREQ) port map(
 		addr	=>abus(23 downto 0),


### PR DESCRIPTION
This change fixes an issue with the MFP V-DISP signal when the CRTC dynamically switches between video modes.

In Keeper, switching from 31 kHz to 24 kHz worked, but attempting to return to 31 kHz or switch to 15 kHz caused the game to freeze. The V-DISP handling was adjusted so that the MFP continues to receive the correct display timing information after a dynamic CRTC mode change.

The fix was tested with Keeper by switching repeatedly between 15 kHz, 24 kHz, and 31 kHz modes. Several other games were also tested, and no regressions were found.